### PR TITLE
Fix Deprecated Web API (Clipboard)

### DIFF
--- a/content.js
+++ b/content.js
@@ -39,7 +39,7 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
 	    clip += summary[i] +".\n";
 	}
 	if (msg.copy_clipboard){
-	    saveToClipboard(clip);
+		navigator.clipboard.writeText(clip);
 	}
 	if (!msg.no_alert){
 	    alert(summary_alert);
@@ -49,15 +49,3 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
     }
     sendResponse({});
 });
-
-
-function saveToClipboard(str) {
-    var textArea = document.createElement("textarea");
-    textArea.style.cssText = "position:absolute;left:-100%";
-    document.body.appendChild(textArea);
-    textArea.value = str;
-    textArea.select();
-    document.execCommand("copy");
-    //alert("copied" +textArea.value);    
-    document.body.removeChild(textArea);
-}


### PR DESCRIPTION
`document.execCommand("copy")` is a deprecated Web API, so it is better to move to `navigator.clipboard.writeText()` since IE is no longer supported.

`document.execCommand("copy")` は非推奨のWeb APIで、先日IEがサポート対象外になった為HTML5のClipboard APIである `navigator.clipboard.writeText()` に移行したほうが安全面・パフォーマンス面で良いと思います。

https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText